### PR TITLE
Make picante pass R CMD check

### DIFF
--- a/R/phylodiversity.R
+++ b/R/phylodiversity.R
@@ -55,7 +55,7 @@ function(samp,phylo,metric=c("cij","checkerboard","jaccard","doij"),
 	taxa.names <- rownames(as.matrix(phylo.dist))
 	samp.dist <- as.dist(as.matrix(species.dist(samp,metric))[taxa.names,taxa.names])
     results$quantile <- quant
-    qrres <- coef(rq(samp.dist~phylo.dist,tau=quant, na.action=na.omit))
+    qrres <- coef(quantreg::rq(samp.dist~phylo.dist,tau=quant, na.action=na.omit))
     names(qrres) <- NULL
     results$obs.qr.intercept <- qrres[1] 
 	results$obs.qr.slope <- qrres[2]
@@ -67,19 +67,19 @@ function(samp,phylo,metric=c("cij","checkerboard","jaccard","doij"),
 	if (null.model=="sample.taxa.labels") for (run in 1:runs)
 	{
 		phylo.dist <- as.dist(taxaShuffle(as.matrix(phylo.dist))[taxa.names,taxa.names])
-		results$random.qr.slopes[run] <- coef(rq(samp.dist~phylo.dist,tau=quant,
+		results$random.qr.slopes[run] <- coef(quantreg::rq(samp.dist~phylo.dist,tau=quant,
 		    na.action=na.omit))[2]
 	}
 	else if (null.model=="pool.taxa.labels") for (run in 1:runs)
 	{
 		phylo.dist <- as.dist(taxaShuffle(as.matrix(pool.phylo.dist))[taxa.names,taxa.names])
-		results$random.qr.slopes[run] <- coef(rq(samp.dist~phylo.dist,tau=quant,
+		results$random.qr.slopes[run] <- coef(quantreg::rq(samp.dist~phylo.dist,tau=quant,
 		    na.action=na.omit))[2]
 	}
 	else for (run in 1:runs)
 	{
 		samp.dist <- species.dist(randomizeMatrix(samp,null.model,...),metric)
-		results$random.qr.slopes[run] <- coef(rq(samp.dist~phylo.dist,tau=quant,
+		results$random.qr.slopes[run] <- coef(quantreg::rq(samp.dist~phylo.dist,tau=quant,
 		    na.action=na.omit))[2]
 	}
 	results$obs.rank <- rank(as.vector(c(results$obs.qr.slope,results$random.qr.slopes)))[1]

--- a/R/sppregs.R
+++ b/R/sppregs.R
@@ -75,7 +75,7 @@ sppregs<-function(samp,env,tree=NULL,fam="gaussian"){
     for(i in 1:nspp)
     {
       y<-samp[,i]
-      mod<-brglm(formu,data=data.frame(cbind(y,env)))
+      mod<-brglm::brglm(formu,data=data.frame(cbind(y,env)))
       spp.resids<-cbind(spp.resids,mod$y-mod$fitted.values)
       spp.fits<-cbind(spp.fits,mod$fitted.values)
       spp.coef<-cbind(spp.coef,summary(mod)$coef[,1])


### PR DESCRIPTION
Current R CMD check performs more stringent tests on the import and
use of functions in external packages. A lightway method of passing
R CMD check is to explicitly refer to the NAMESPACE of these
packages, e.g., `quantreg::rq()`. A heavier alternative (in another
branch) is to change dependencies in DESCRIPTION and import these
functions, so that NAMESPACE would have lines like

```
    importFrom(quantreg, rq)
```

and to remove `require(quantreg)` in the function body.

Current R CMD check result is at http://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-debian-clang/picante-00check.html

This pull request contains a light-weight fix which adds `::`. Alternative suggestion that changes dependencies in DESCRIPTION and makes explicit `imporFrom` is available in another branch 
jarioksa/picante@d5cde4f81153c4e72544db154eb98d163244be78
