### PR TITLE
fix issue #1 matrix2sample fails if rownames missing

### DIFF
--- a/R/phylocom.R
+++ b/R/phylocom.R
@@ -15,7 +15,8 @@ function(x) {
 
 `matrix2sample` <-
 function(z) {
-	temp <- data.frame(expand.grid(dimnames(z))[1:2], as.vector(as.matrix(z)))
+	temp <- data.frame(expand.grid(dimnames(provideDimnames(z)))[1:2],
+                           as.vector(as.matrix(z)))
 	temp <- temp[(temp[, 3] > 0) & !is.na(temp[, 3]), ]
 	temp <- temp[sort.list(temp[, 1]), ]
 	data.frame(plot=temp[, 1], abund=temp[, 3], id=temp[, 2])


### PR DESCRIPTION
test case

```
data(dune)
x <- as.matrix(dune)
rownames(x) # missing
matrix2sample(x)
```
