### PR TITLE
Modifications to pd() function to improve speed

### DIFF
--- a/R/phylodiversity.R
+++ b/R/phylodiversity.R
@@ -543,16 +543,16 @@ psd<-function(samp,tree,compute.var=TRUE,scale.vcv=TRUE){
 }
 
 pd <- function (samp, tree, include.root = TRUE) {
-    if (is.null(tree$edge.length)) {
-        stop("Tree has no branch lengths, cannot compute pd")
+		if (is.null(tree$edge.length)) {
+      stop("Tree has no branch lengths, cannot compute pd")
     }
 		if (include.root) {
-				# Make sure tree is rooted if needed
-				if (!is.rooted(tree)) {
-					stop("Rooted tree required to calculate PD with include.root=TRUE argument")
-					}
-    		tree <- node.age(tree)
+			# Make sure tree is rooted if needed
+			if (!is.rooted(tree)) {
+				stop("Rooted tree required to calculate PD with include.root=TRUE argument")
 				}
+    	tree <- node.age(tree)
+			}
     species <- colnames(samp)
     SR <- rowSums(ifelse(samp > 0, 1, 0))
     nlocations <- dim(samp)[1]

--- a/R/phylodiversity.R
+++ b/R/phylodiversity.R
@@ -57,13 +57,13 @@ function(samp,phylo,metric=c("cij","checkerboard","jaccard","doij"),
     results$quantile <- quant
     qrres <- coef(quantreg::rq(samp.dist~phylo.dist,tau=quant, na.action=na.omit))
     names(qrres) <- NULL
-    results$obs.qr.intercept <- qrres[1] 
+    results$obs.qr.intercept <- qrres[1]
 	results$obs.qr.slope <- qrres[2]
-	
+
 	if (show.plot) {
-        plot(samp.dist~phylo.dist,xlab="Phylogenetic distance",ylab="Co-occurrence")   
+        plot(samp.dist~phylo.dist,xlab="Phylogenetic distance",ylab="Co-occurrence")
     }
-	
+
 	if (null.model=="sample.taxa.labels") for (run in 1:runs)
 	{
 		phylo.dist <- as.dist(taxaShuffle(as.matrix(phylo.dist))[taxa.names,taxa.names])
@@ -86,7 +86,7 @@ function(samp,phylo,metric=c("cij","checkerboard","jaccard","doij"),
 	results$obs.qr.slope.p <- results$obs.rank/(runs+1)
 
 	if (show.plot) {
-        abline(results$obs.qr.intercept,results$obs.qr.slope)   
+        abline(results$obs.qr.intercept,results$obs.qr.slope)
         legend("topleft",paste("q",as.character(quant),sep=""))
     }
 
@@ -104,14 +104,14 @@ function(x) {
 	return(x)
 }
 
-`tipShuffle` <- 
+`tipShuffle` <-
 function(phy) {
     phy$tip.label <- phy$tip.label[sample(length(phy$tip.label))]
     return(phy)
 }
 
 
-mpd <- function(samp, dis, abundance.weighted=FALSE) 
+mpd <- function(samp, dis, abundance.weighted=FALSE)
 {
     N <- dim(samp)[1]
     mpd <- numeric(N)
@@ -121,11 +121,11 @@ mpd <- function(samp, dis, abundance.weighted=FALSE)
             sample.dis <- dis[sppInSample, sppInSample]
             if (abundance.weighted) {
                 sample.weights <- t(as.matrix(samp[i,sppInSample,drop=FALSE])) %*% as.matrix(samp[i,sppInSample,drop=FALSE])
-                mpd[i] <- weighted.mean(sample.dis,sample.weights)  
+                mpd[i] <- weighted.mean(sample.dis,sample.weights)
 
             }
             else {
-                mpd[i] <- mean(sample.dis[lower.tri(sample.dis)])         
+                mpd[i] <- mean(sample.dis[lower.tri(sample.dis)])
             }
         }
         else{
@@ -165,9 +165,9 @@ mntd <- function(samp, dis, abundance.weighted=FALSE)
 
 
 `ses.mpd` <-
-function (samp, dis, null.model = c("taxa.labels", "richness", "frequency", "sample.pool", 
+function (samp, dis, null.model = c("taxa.labels", "richness", "frequency", "sample.pool",
     "phylogeny.pool", "independentswap", "trialswap"),
-    abundance.weighted = FALSE, runs = 999, iterations = 1000) 
+    abundance.weighted = FALSE, runs = 999, iterations = 1000)
 {
     dis <- as.matrix(dis)
     mpd.obs <- mpd(samp, dis, abundance.weighted = abundance.weighted)
@@ -175,7 +175,7 @@ function (samp, dis, null.model = c("taxa.labels", "richness", "frequency", "sam
     mpd.rand <- switch(null.model,
     	taxa.labels = t(replicate(runs, mpd(samp, taxaShuffle(dis), abundance.weighted=abundance.weighted))),
     	richness = t(replicate(runs, mpd(randomizeMatrix(samp,null.model="richness"), dis, abundance.weighted))),
-    	frequency = t(replicate(runs, mpd(randomizeMatrix(samp,null.model="frequency"), dis, abundance.weighted))),    	
+    	frequency = t(replicate(runs, mpd(randomizeMatrix(samp,null.model="frequency"), dis, abundance.weighted))),
     	sample.pool = t(replicate(runs, mpd(randomizeMatrix(samp,null.model="richness"), dis, abundance.weighted))),
     	phylogeny.pool = t(replicate(runs, mpd(randomizeMatrix(samp,null.model="richness"),
     		taxaShuffle(dis), abundance.weighted))),
@@ -185,18 +185,18 @@ function (samp, dis, null.model = c("taxa.labels", "richness", "frequency", "sam
     mpd.rand.mean <- apply(X = mpd.rand, MARGIN = 2, FUN = mean, na.rm=TRUE)
     mpd.rand.sd <- apply(X = mpd.rand, MARGIN = 2, FUN = sd, na.rm=TRUE)
     mpd.obs.z <- (mpd.obs - mpd.rand.mean)/mpd.rand.sd
-    mpd.obs.rank <- apply(X = rbind(mpd.obs, mpd.rand), MARGIN = 2, 
+    mpd.obs.rank <- apply(X = rbind(mpd.obs, mpd.rand), MARGIN = 2,
         FUN = rank)[1, ]
-    mpd.obs.rank <- ifelse(is.na(mpd.rand.mean),NA,mpd.obs.rank)    
-    data.frame(ntaxa=specnumber(samp),mpd.obs, mpd.rand.mean, mpd.rand.sd, mpd.obs.rank, 
+    mpd.obs.rank <- ifelse(is.na(mpd.rand.mean),NA,mpd.obs.rank)
+    data.frame(ntaxa=specnumber(samp),mpd.obs, mpd.rand.mean, mpd.rand.sd, mpd.obs.rank,
         mpd.obs.z, mpd.obs.p=mpd.obs.rank/(runs+1),runs=runs, row.names = row.names(samp))
 }
 
 
 `ses.mntd` <-
-function (samp, dis, null.model = c("taxa.labels", "richness", "frequency", "sample.pool", 
+function (samp, dis, null.model = c("taxa.labels", "richness", "frequency", "sample.pool",
     "phylogeny.pool", "independentswap", "trialswap"),
-    abundance.weighted = FALSE, runs = 999, iterations = 1000) 
+    abundance.weighted = FALSE, runs = 999, iterations = 1000)
 {
     dis <- as.matrix(dis)
     mntd.obs <- mntd(samp, dis, abundance.weighted)
@@ -214,10 +214,10 @@ function (samp, dis, null.model = c("taxa.labels", "richness", "frequency", "sam
     mntd.rand.mean <- apply(X = mntd.rand, MARGIN = 2, FUN = mean, na.rm=TRUE)
     mntd.rand.sd <- apply(X = mntd.rand, MARGIN = 2, FUN = sd, na.rm=TRUE)
     mntd.obs.z <- (mntd.obs - mntd.rand.mean)/mntd.rand.sd
-    mntd.obs.rank <- apply(X = rbind(mntd.obs, mntd.rand), MARGIN = 2, 
+    mntd.obs.rank <- apply(X = rbind(mntd.obs, mntd.rand), MARGIN = 2,
         FUN = rank)[1, ]
-    mntd.obs.rank <- ifelse(is.na(mntd.rand.mean),NA,mntd.obs.rank)     
-    data.frame(ntaxa=specnumber(samp),mntd.obs, mntd.rand.mean, mntd.rand.sd, mntd.obs.rank, 
+    mntd.obs.rank <- ifelse(is.na(mntd.rand.mean),NA,mntd.obs.rank)
+    data.frame(ntaxa=specnumber(samp),mntd.obs, mntd.rand.mean, mntd.rand.sd, mntd.obs.rank,
         mntd.obs.z, mntd.obs.p=mntd.obs.rank/(runs+1),runs=runs, row.names = row.names(samp))
 }
 
@@ -225,7 +225,7 @@ function (samp, dis, null.model = c("taxa.labels", "richness", "frequency", "sam
 psv<-function(samp,tree,compute.var=TRUE,scale.vcv=TRUE){
   # Make samp matrix a pa matrix
   samp[samp>0]<-1
-  
+
   flag=0
   if (is.null(dim(samp))) #if the samp matrix only has one site
   {
@@ -249,17 +249,17 @@ psv<-function(samp,tree,compute.var=TRUE,scale.vcv=TRUE){
     Cmatrix<-Cmatrix[species,species]
     samp<-samp[,colnames(Cmatrix)]
   }
-  
+
     # numbers of locations and species
     SR<-rowSums(samp)
     nlocations<-dim(samp)[1]
     nspecies<-dim(samp)[2]
-  
+
     ##################################
     # calculate observed PSVs
     #
     PSVs<-NULL
-  
+
     for(i in 1:nlocations)
     {
       index<-seq(1:nrow(Cmatrix))[samp[i,]==1]	#species present
@@ -274,23 +274,23 @@ psv<-function(samp,tree,compute.var=TRUE,scale.vcv=TRUE){
         PSVs<-c(PSVs,PSV)
     }
     PSVout<-cbind(PSVs,SR)
-  
+
   if(flag==2)
   {
     PSVout<-PSVout[-2,]
     return(PSVout)
   } else {
-    if(compute.var==FALSE) 
+    if(compute.var==FALSE)
     {
       return(data.frame(PSVout))
     } else {
-    
+
       PSVvar<-NULL
       X<-Cmatrix-(sum(sum(Cmatrix-diag(nspecies))))/(nspecies*(nspecies-1));
       X<-X-diag(diag(X))
-  
+
       SS1<-sum(X*X)/2
-  
+
       SS2<-0;
       for(i in 1:(nspecies-1)){
         for(j in (i+1):nspecies){
@@ -298,24 +298,24 @@ psv<-function(samp,tree,compute.var=TRUE,scale.vcv=TRUE){
         }
       }
       SS3<--SS1-SS2
-  
+
       S1<-SS1*2/(nspecies*(nspecies-1))
       S2<-SS2*2/(nspecies*(nspecies-1)*(nspecies-2))
-  
+
       if(nspecies==3){
         S3<-0
       }else{
       S3<-SS3*2/(nspecies*(nspecies-1)*(nspecies-2)*(nspecies-3))
       }
-  
+
       for(n in 2:nspecies){
         approxi<-2/(n*(n-1))*(S1 + (n-2)*S2 + (n-2)*(n-3)*S3)
         PSVvar<-rbind(PSVvar, c(n, approxi))
       }
-  
+
       vars<-rep(0,nlocations)
       PSVout<-cbind(PSVout,vars)
-  
+
       for (g in 1:nlocations)
       {
         if(PSVout[g,2]>1)
@@ -332,7 +332,7 @@ psv<-function(samp,tree,compute.var=TRUE,scale.vcv=TRUE){
 
 psr <- function(samp,tree,compute.var=TRUE,scale.vcv=TRUE){
   PSVout<-psv(samp,tree,compute.var,scale.vcv=scale.vcv)
-  if(is.null(dim(PSVout))==TRUE) 
+  if(is.null(dim(PSVout))==TRUE)
   {
     PSRout<-data.frame(cbind(PSVout[1]*PSVout[2],PSVout[2]))
     names(PSRout)<-c("PSR","SR")
@@ -345,7 +345,7 @@ psr <- function(samp,tree,compute.var=TRUE,scale.vcv=TRUE){
       rownames(PSRout)<-rownames(PSVout)
       return(data.frame(PSRout))
     } else {
-      PSRout<-cbind(PSRout,PSVout[,3]*(PSVout[,2])^2)       
+      PSRout<-cbind(PSRout,PSVout[,3]*(PSVout[,2])^2)
       colnames(PSRout)<-c("PSR","SR","vars")
       rownames(PSRout)<-rownames(PSVout)
       return(data.frame(PSRout))
@@ -362,11 +362,11 @@ pse<-function(samp,tree,scale.vcv=TRUE){
   }
 
   samp<-as.matrix(samp)
-  
+
   if(is(tree)[1]=="phylo")
   {
     if(is.null(tree$edge.length)){tree<-compute.brlen(tree, 1)}  #If phylo has no given branch lengths
-    tree<-prune.sample(samp,tree) 
+    tree<-prune.sample(samp,tree)
     # Make sure that the species line up
     samp<-samp[,tree$tip.label, drop=FALSE]
     # Make a correlation matrix of the species pool phylogeny
@@ -379,7 +379,7 @@ pse<-function(samp,tree,scale.vcv=TRUE){
     Cmatrix<-Cmatrix[species,species]
     samp<-samp[,colnames(Cmatrix),drop=FALSE]
   }
-  
+
   # numbers of locations and species
   SR<-apply(samp>0,1,sum)
   nlocations<-dim(samp)[1]
@@ -392,7 +392,7 @@ pse<-function(samp,tree,scale.vcv=TRUE){
     index<-seq(1,ncol(Cmatrix))[samp[i,]>0]	  # species present
     n<-length(index)                          #location species richness
     if(n>1)
-    {    
+    {
     C<-Cmatrix[index,index]		                #C for individual locations
     N<-sum(samp[i,])                          #location total abundance
     M<-samp[i,samp[i,]>0]                  #species abundance column
@@ -405,7 +405,7 @@ pse<-function(samp,tree,scale.vcv=TRUE){
   if (flag==2)
   {
     PSEout<-PSEout[-2,]
-    return(PSEout)  
+    return(PSEout)
   } else {
     return(data.frame(PSEout))
   }
@@ -455,7 +455,7 @@ psc<-function(samp,tree,scale.vcv=TRUE){
     index<-seq(1:nrow(Cmatrix))[samp[i,]==1]	#species present
     n<-length(index)			#number of species present
     if(n>1)
-    {    
+    {
       C<-Cmatrix[index,index]	#C for individual locations
       diag(C)<--1
       PSC<- 1-(sum(apply(C,1,max))/n)
@@ -466,7 +466,7 @@ psc<-function(samp,tree,scale.vcv=TRUE){
  if (flag==2)
   {
     PSCout<-PSCout[-2,]
-    return(PSCout)  
+    return(PSCout)
   } else {
     return(data.frame(PSCout))
   }
@@ -478,7 +478,7 @@ psv.spp<-function(samp,tree){
   if (is.null(dim(samp))) #if the samp matrix only has one site
   {
     samp<-rbind(samp,samp)
-  }  
+  }
   if(is(tree)[1]=="phylo")
   {
     if(is.null(tree$edge.length)){tree<-compute.brlen(tree, 1)}  #If phylo has no given branch lengths
@@ -542,52 +542,66 @@ psd<-function(samp,tree,compute.var=TRUE,scale.vcv=TRUE){
   }
 }
 
-pd <- function (samp, tree, include.root = TRUE) 
-{
+pd <- function (samp, tree, include.root = TRUE) {
     if (is.null(tree$edge.length)) {
         stop("Tree has no branch lengths, cannot compute pd")
     }
+    tree <- node.age(tree)
     species <- colnames(samp)
     SR <- rowSums(ifelse(samp > 0, 1, 0))
-    nlocations = dim(samp)[1]
-    nspecies = dim(samp)[2]
-    PDs = NULL
+    nlocations <- dim(samp)[1]
+    nspecies <- dim(samp)[2]
+    PDs <- rep(NA, nlocations)
+
     for (i in 1:nlocations) {
         present <- species[samp[i, ] > 0]
-        treeabsent <- tree$tip.label[which(!(tree$tip.label %in% 
-            present))]
+        treeabsent <- tree$tip.label[which(!(tree$tip.label %in% present))]
+        # Check that sample has species; If no species are present, PD = 0
         if (length(present) == 0) {
-            PD <- 0
+            PDs[i] <- 0
         }
+        # Check if there is only ONE species in sample
         else if (length(present) == 1) {
+            # If tree is not rooted, parse error message
             if (!is.rooted(tree) || !include.root) {
-                warning("Rooted tree and include.root=TRUE argument required to calculate PD of single-species sampunities. Single species sampunity assigned PD value of NA.")
-                PD <- NA
+                warning("Rooted tree and include.root=TRUE argument required to calculate PD of single-species communities. Single species community assigned PD value of NA.")
+                PDs[i] <- NA
             }
+            # Else the PD is the node age of that single species present
             else {
-                PD <- node.age(tree)$ages[which(tree$edge[, 2] == 
+                PDs[i] <- tree$ages[which(tree$edge[, 2] ==
                   which(tree$tip.label == present))]
             }
         }
+        # If there are no absent species (all tips are in sample) then PD
+        # is the sum of all edges in the tree
         else if (length(treeabsent) == 0) {
-            PD <- sum(tree$edge.length)
+            PDs[i] <- sum(tree$edge.length)
         }
+        # Otherwise, we will need to remove absent species
         else {
+            # Make a SubTree with only present species
             sub.tree <- drop.tip(tree, treeabsent)
+            # If the tree is rooted, you need to account for different in
+            # maximum branch length between subtree and original
             if (include.root) {
+                # Make sure tree is rooted if needed
                 if (!is.rooted(tree)) {
                   stop("Rooted tree required to calculate PD with include.root=TRUE argument")
                 }
+                # Calculate diff btw max depth original and max depth subtree
                 sub.tree.depth <- max(node.age(sub.tree)$ages)
-                orig.tree.depth <- max(node.age(tree)$ages[which(tree$edge[,2] %in% which(tree$tip.label %in% present))])
-                PD <- sum(sub.tree$edge.length) + (orig.tree.depth - 
+                orig.tree.depth <- max(tree$ages[which(tree$edge[,2] %in% which(tree$tip.label %in% present))])
+                # PD is the sum of edges in subtree, plus any difference in the
+                # max distance (of only present tips) between original and sub
+                PDs[i] <- sum(sub.tree$edge.length) + (orig.tree.depth -
                   sub.tree.depth)
             }
+            # If root is not included, just add all edges
             else {
-                PD <- sum(sub.tree$edge.length)
+                PDs[i] <- sum(sub.tree$edge.length)
             }
         }
-        PDs <- c(PDs, PD)
     }
     PDout <- data.frame(PD = PDs, SR = SR)
     rownames(PDout) <- rownames(samp)
@@ -595,15 +609,15 @@ pd <- function (samp, tree, include.root = TRUE)
 }
 
 `ses.pd` <-
-function (samp, tree, null.model = c("taxa.labels", "richness", "frequency", "sample.pool", 
-    "phylogeny.pool", "independentswap", "trialswap"), runs = 999, iterations = 1000, ...) 
+function (samp, tree, null.model = c("taxa.labels", "richness", "frequency", "sample.pool",
+    "phylogeny.pool", "independentswap", "trialswap"), runs = 999, iterations = 1000, ...)
 {
     pd.obs <- as.vector(pd(samp, tree, ...)$PD)
     null.model <- match.arg(null.model)
     pd.rand <- switch(null.model,
     	taxa.labels = t(replicate(runs, as.vector(pd(samp, tipShuffle(tree), ...)$PD))),
     	richness = t(replicate(runs, as.vector(pd(randomizeMatrix(samp,null.model="richness"), tree, ...)$PD))),
-    	frequency = t(replicate(runs, as.vector(pd(randomizeMatrix(samp,null.model="frequency"), tree, ...)$PD))),    	
+    	frequency = t(replicate(runs, as.vector(pd(randomizeMatrix(samp,null.model="frequency"), tree, ...)$PD))),
     	sample.pool = t(replicate(runs, as.vector(pd(randomizeMatrix(samp,null.model="richness"), tree, ...)$PD))),
     	phylogeny.pool = t(replicate(runs, as.vector(pd(randomizeMatrix(samp,null.model="richness"),
     		tipShuffle(tree), ...)$PD))),
@@ -613,9 +627,9 @@ function (samp, tree, null.model = c("taxa.labels", "richness", "frequency", "sa
     pd.rand.mean <- apply(X = pd.rand, MARGIN = 2, FUN = mean, na.rm=TRUE)
     pd.rand.sd <- apply(X = pd.rand, MARGIN = 2, FUN = sd, na.rm=TRUE)
     pd.obs.z <- (pd.obs - pd.rand.mean)/pd.rand.sd
-    pd.obs.rank <- apply(X = rbind(pd.obs, pd.rand), MARGIN = 2, 
+    pd.obs.rank <- apply(X = rbind(pd.obs, pd.rand), MARGIN = 2,
         FUN = rank)[1, ]
-    pd.obs.rank <- ifelse(is.na(pd.rand.mean),NA,pd.obs.rank)    
-    data.frame(ntaxa=specnumber(samp),pd.obs, pd.rand.mean, pd.rand.sd, pd.obs.rank, 
+    pd.obs.rank <- ifelse(is.na(pd.rand.mean),NA,pd.obs.rank)
+    data.frame(ntaxa=specnumber(samp),pd.obs, pd.rand.mean, pd.rand.sd, pd.obs.rank,
         pd.obs.z, pd.obs.p=pd.obs.rank/(runs+1),runs=runs, row.names = row.names(samp))
 }

--- a/R/phylodiversity.R
+++ b/R/phylodiversity.R
@@ -546,7 +546,13 @@ pd <- function (samp, tree, include.root = TRUE) {
     if (is.null(tree$edge.length)) {
         stop("Tree has no branch lengths, cannot compute pd")
     }
-    tree <- node.age(tree)
+		if (include.root) {
+				# Make sure tree is rooted if needed
+				if (!is.rooted(tree)) {
+					stop("Rooted tree required to calculate PD with include.root=TRUE argument")
+					}
+    		tree <- node.age(tree)
+				}
     species <- colnames(samp)
     SR <- rowSums(ifelse(samp > 0, 1, 0))
     nlocations <- dim(samp)[1]


### PR DESCRIPTION
I modified the pd function and drastically increased speed. Improvements are based on replacing values in a vector instead of concatenating inside a loop, and I reduced the number of times node.age() was run by putting a global node.age function outside of the loop. Performance increases are shown below: 

```
> # pd = original code; pd2 = modified code
> 
> # Phylomom Data via picante
> dim(phylocom$sample)
[1]  6 25
> 
> microbenchmark(pd(phylocom$sample, phylocom$phylo, include.root = F), 
+                pd2(phylocom$sample, phylocom$phylo, include.root = F), times = 3)
Unit: milliseconds
                                                   expr      min       lq     mean   median
  pd(phylocom$sample, phylocom$phylo, include.root = F) 3.486191 3.549235 3.642661 3.612280
 pd2(phylocom$sample, phylocom$phylo, include.root = F) 4.365821 4.527785 4.898558 4.689748
       uq      max neval
 3.720897 3.829513     3
 5.164926 5.640104     3
> 
> microbenchmark(pd(phylocom$sample, phylocom$phylo, include.root = T), 
+                pd2(phylocom$sample, phylocom$phylo, include.root = T), times = 3)
Unit: milliseconds
                                                   expr      min        lq      mean
  pd(phylocom$sample, phylocom$phylo, include.root = T) 10.48036 10.513766 10.639581
 pd2(phylocom$sample, phylocom$phylo, include.root = T)  6.07949  6.163944  6.301157
    median       uq       max neval
 10.547176 10.71919 10.891209     3
  6.248397  6.41199  6.575584     3
> 
> # OTU table and phylogeny rarefied to 3,000 obs per site
> dim(OTU.2)
[1]    58 17314
> 
> microbenchmark(pd(OTU.2, OTU.tre.2, include.root = F), 
+                pd2(OTU.2, OTU.tre.2, include.root = F), times = 3)
Unit: seconds
                                    expr      min       lq     mean   median       uq
  pd(OTU.2, OTU.tre.2, include.root = F) 33.23346 33.28569 33.71187 33.33791 33.95107
 pd2(OTU.2, OTU.tre.2, include.root = F) 51.13831 51.23522 51.27740 51.33214 51.34694
      max neval
 34.56423     3
 51.36174     3
> 
> 
> microbenchmark(pd(OTU.2, OTU.tre.2, include.root = T), 
+                pd2(OTU.2, OTU.tre.2, include.root = T), times = 3)
Unit: seconds
                                    expr        min         lq       mean    median
  pd(OTU.2, OTU.tre.2, include.root = T) 1102.04643 1109.72308 1116.85816 1117.3997
 pd2(OTU.2, OTU.tre.2, include.root = T)   54.08965   56.48848   58.33705   58.8873
         uq       max neval
 1124.26402 1131.1283     3
   60.46075   62.0342     3
```
