### PR TITLE
Update match.comm.dist

### DIFF
--- a/R/data.checking.R
+++ b/R/data.checking.R
@@ -144,9 +144,9 @@ match.comm.dist <- function(comm, dis) {
     }
     
     if (disclass == "dist") {
-        res$dist <- as.dist(dis[colnames(comm),colnames(comm)])
+        res$dist <- as.dist(dis[colnames(res$comm),colnames(res$comm)])
     } else {
-        res$dist <- dis[colnames(comm),colnames(comm)]
+        res$dist <- dis[colnames(res$comm),colnames(res$comm)]
     }
     return(res)   
 


### PR DESCRIPTION
When the phylognetic distance matrix has less species than the community matrix, `dis[colnames(comm), colnames(comm)]` will throw an error about out of bounce. Use `dis[colnames(res$comm), colnames(res$comm)]` instead.